### PR TITLE
Cookie clear on refresh bugfix

### DIFF
--- a/Backend/Controllers/AuthConttrollers/facebookAuthController.js
+++ b/Backend/Controllers/AuthConttrollers/facebookAuthController.js
@@ -15,6 +15,7 @@ function authorize(req, res) {
             httpOnly: true,
             sameSite: 'Lax',
             secure: false,
+            path: '/',
             maxAge: 100 * 60 * 60, // 1 hour ...
         });
         const frontendURL = fetchFrontendApplicationRunningURL();

--- a/Backend/Controllers/AuthConttrollers/googleAuthController.js
+++ b/Backend/Controllers/AuthConttrollers/googleAuthController.js
@@ -15,6 +15,7 @@ function authorize(req, res) {
             httpOnly: true,
             sameSite: 'Lax',
             secure: false,
+            path: '/',
             maxAge: 100 * 60 * 60, // 1 hour ...
         });
         const frontendURL = fetchFrontendApplicationRunningURL();

--- a/Backend/Controllers/adminController.js
+++ b/Backend/Controllers/adminController.js
@@ -89,6 +89,7 @@ async function login (req, res) {
                 httpOnly: true,
                 sameSite: 'none',
                 secure: true,
+                path: '/',
                 maxAge: 24 * 60 * 60 * 1000, // 24 hours
             });
 

--- a/Backend/Controllers/authController.js
+++ b/Backend/Controllers/authController.js
@@ -73,6 +73,7 @@ async function register(req, res) {
                     httpOnly: true,
                     sameSite: 'Lax',
                     secure: false,
+                    path: '/', // Add this line
                     maxAge: 60 * 60 * 1000, // 1 hour ...
                 }).status(200).json({ 
                     message: "User registered and logged in successfully", 
@@ -130,6 +131,7 @@ async function login(req, res) {
                 httpOnly: true,
                 sameSite: 'Lax',
                 secure: false,
+                path: '/', 
                 maxAge: 60 * 60 * 1000, // 1 hour ...
             }).status(200).json({ 
                 message: "User logged in successfully",

--- a/Client_Frontend/src/App.jsx
+++ b/Client_Frontend/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
   return (
     <Router>
       <ScrollToTop />
-      <WindowOnClose/>
+      {/* <WindowOnClose/> */}
       <div className="flex flex-col min-h-screen">
         <Toaster position="top-center" />
         <Navbar />


### PR DESCRIPTION
The WindowOnClose was clearing the local storage upon closing of a window or a refresh causing to the deletion of the JWT token in cookies. Plus add a path property to every cookie configuration to maintain consistency of cookies.